### PR TITLE
Update runner selection for lint

### DIFF
--- a/.github/workflows/buildAndTestCMake.yml
+++ b/.github/workflows/buildAndTestCMake.yml
@@ -43,7 +43,7 @@ jobs:
       STABLEHLO_PYTHON_BUILD_DIR: "stablehlo-python-build"
     strategy:
       fail-fast: false
-    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-latest'  }}
+    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
 
     steps:
     - name: Checkout StableHLO

--- a/.github/workflows/buildAndTestCMake.yml
+++ b/.github/workflows/buildAndTestCMake.yml
@@ -43,7 +43,7 @@ jobs:
       STABLEHLO_PYTHON_BUILD_DIR: "stablehlo-python-build"
     strategy:
       fail-fast: false
-    runs-on: ubuntu-22.04-64core
+    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-latest'  }}
 
     steps:
     - name: Checkout StableHLO

--- a/.github/workflows/buildBazel.yml
+++ b/.github/workflows/buildBazel.yml
@@ -38,7 +38,7 @@ jobs:
   bazel-build:
     strategy:
       fail-fast: false
-    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-latest'  }}
+    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
 
     steps:
     - name: Checkout StableHLO

--- a/.github/workflows/buildBazel.yml
+++ b/.github/workflows/buildBazel.yml
@@ -38,7 +38,7 @@ jobs:
   bazel-build:
     strategy:
       fail-fast: false
-    runs-on: ubuntu-22.04-64core
+    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-latest'  }}
 
     steps:
     - name: Checkout StableHLO

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,8 +21,9 @@ on:
 jobs:
   clang-format:
     # This job can only be run on pull_request since GITHUB_BASE_REF is only set on PR.
+    # In forks, run this on public GH runners. 64core infra will ignore jobs from forks.
     if: "github.event_name == 'pull_request'"
-    runs-on: ubuntu-22.04-64core
+    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-latest'  }}
     steps:
       - name: Checking out repository
         uses: actions/checkout@v2
@@ -35,7 +36,7 @@ jobs:
   whitespace-checks:
     # This job can only be run on pull_request since GITHUB_BASE_REF is only set on PR.
     if: "github.event_name == 'pull_request'"
-    runs-on: ubuntu-22.04-64core
+    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-latest'  }}
     steps:
       - name: Checking out repository
         uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
     # This job can only be run on pull_request since GITHUB_BASE_REF is only set on PR.
     # In forks, run this on public GH runners. 64core infra will ignore jobs from forks.
     if: "github.event_name == 'pull_request'"
-    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-latest'  }}
+    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
     steps:
       - name: Checking out repository
         uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
   whitespace-checks:
     # This job can only be run on pull_request since GITHUB_BASE_REF is only set on PR.
     if: "github.event_name == 'pull_request'"
-    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-latest'  }}
+    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
     steps:
       - name: Checking out repository
         uses: actions/checkout@v2

--- a/.github/workflows/markdown_lint.yml
+++ b/.github/workflows/markdown_lint.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   markdown-lint:
-    runs-on: ubuntu-22.04-64core
+    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-latest'  }}
     steps:
     - name: Checking out repository
       uses: actions/checkout@v3

--- a/.github/workflows/markdown_lint.yml
+++ b/.github/workflows/markdown_lint.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   markdown-lint:
-    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-latest'  }}
+    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
     steps:
     - name: Checking out repository
       uses: actions/checkout@v3


### PR DESCRIPTION
Resolves actions stalling endlessly on forks with:
<img width="662" alt="image" src="https://user-images.githubusercontent.com/3036970/216694700-4b071f21-2408-4d37-b594-889b0ced2b24.png">


See: https://github.com/GleasonK/stablehlo/actions/runs/4087406604
- clang-format has the change and uses the public runner
- lint whitespace does not and waits for runner

